### PR TITLE
DRAFT - Database Redesign for Group Conversations

### DIFF
--- a/server/messenger_backend/models/conversation.py
+++ b/server/messenger_backend/models/conversation.py
@@ -1,28 +1,9 @@
 from django.db import models
-from django.db.models import Q
 
 from . import utils
-from .user import User
 
 
 class Conversation(utils.CustomModel):
-
-    user1 = models.ForeignKey(
-        User, on_delete=models.CASCADE, db_column="user1Id", related_name="+"
-    )
-    user2 = models.ForeignKey(
-        User, on_delete=models.CASCADE, db_column="user2Id", related_name="+", 
-    )
+    name = models.CharField(blank=True, null=True, default=None)
     createdAt = models.DateTimeField(auto_now_add=True, db_index=True)
     updatedAt = models.DateTimeField(auto_now=True)
-
-    # find conversation given two user Ids
-    def find_conversation(user1Id, user2Id):
-        # return conversation or None if it doesn't exist
-        try:
-            return Conversation.objects.get(
-                (Q(user1__id=user1Id) | Q(user1__id=user2Id)),
-                (Q(user2__id=user1Id) | Q(user2__id=user2Id)),
-            )
-        except Conversation.DoesNotExist:
-            return None

--- a/server/messenger_backend/models/conversationUser.py
+++ b/server/messenger_backend/models/conversationUser.py
@@ -1,0 +1,16 @@
+from django.db import models
+
+from . import utils
+from .user import User
+from .conversation import Conversation
+
+
+class ConversationUser(utils.CustomModel):
+    user = models.ForeignKey(
+        User, on_delete=models.CASCADE, db_column="userId", related_name="+"
+    )
+    conversation = models.ForeignKey(
+        Conversation, on_delete=models.CASCADE, db_column="conversationId", related_name="+"
+    )
+    createdAt = models.DateTimeField(auto_now_add=True, db_index=True)
+    updatedAt = models.DateTimeField(auto_now=True)

--- a/server/messenger_backend/models/message.py
+++ b/server/messenger_backend/models/message.py
@@ -6,7 +6,7 @@ from .conversation import Conversation
 
 class Message(utils.CustomModel):
     text = models.TextField(null=False)
-    senderId = models.IntegerField(null=False)
+    conversationUserId = models.IntegerField(null=False)
     conversation = models.ForeignKey(
         Conversation,
         on_delete=models.CASCADE,

--- a/server/messenger_backend/models/message.py
+++ b/server/messenger_backend/models/message.py
@@ -2,11 +2,14 @@ from django.db import models
 
 from . import utils
 from .conversation import Conversation
+from .conversationUser import ConversationUser
 
 
 class Message(utils.CustomModel):
     text = models.TextField(null=False)
-    conversationUserId = models.IntegerField(null=False)
+    conversationUser = models.ForeignKey(
+        ConversationUser, on_delete=models.CASCADE, db_column="conversationUserId", related_name="+"
+    )
     conversation = models.ForeignKey(
         Conversation,
         on_delete=models.CASCADE,

--- a/server/messenger_backend/models/readStatus.py
+++ b/server/messenger_backend/models/readStatus.py
@@ -7,12 +7,13 @@ from django.db.models.signals import post_save
 from . import utils
 from .user import User
 from .conversation import Conversation
+from .conversationUser import ConversationUser
 from .message import Message
 
 
 class ReadStatus(utils.CustomModel):
     userId = models.ForeignKey(
-        User, on_delete=models.CASCADE, related_name="+"
+        ConversationUser, on_delete=models.CASCADE, related_name="+"
     )   
     conversation = models.ForeignKey(
         Conversation,


### PR DESCRIPTION
closes #5
## Description
Changed the models to fit the new database design.

### Ways we could have designed the database for this feature
1. We could have added a `GroupConversation` model and a `GroupConversationModel`. This would mean that we would not have to deal with migrating data, however, in the future, if we wanted to add more fields to a conversation, we would have to update the `Conversation` model and the `GroupConversatio` model.
2. We could modify that `Conversation` model that holds no users and add a `ConverastionUser` model that has a reference to the `Conversation` and the `User`. This would mean that all conversations are created and treated the same, which simplifies things. However, when migrating data, it will be tricky to save the existing conversations and convert them to the new `Conversation` model. (I went with this one)

### **What additional (non-database) changes are needed to implement this feature (we want this to be high level but thorough)?**
**Backend**
There will need to be multiple changes made to the backend.
**Messages**
There will need to be a few changes to how we handle adding new messages to a conversation.
First, we will need to change how we are creating new conversations. Instead of creating a new `conversation` by passing in `user1_id` and `user2_id`, we will need to make 2 new database objects of `conversationUser` which will have a reference to the new `conversation`.
Next, when we are adding a new message to a `conversation`, we will need to create a new message by passing in the `conversationUserId` instead of just the `userId`.
**Conversations**
We will have to change how we fetch all conversations for a user. Instead of filtering all conversations, we can just filter all `conversationUsers` where the `user` is equal to the `user_id` of the user requesting all messages.
We will also have to change the shape of the data a little bit. The `otherUser` object will have to be changed to an array of `otherUsers`, that has the same properties as the existing `otherUser` object.
**Front end**
As far as I can tell, minimal functional changes will be needed on the front end. All the conversation data will be fetched the same, however, the conversation data will have a slightly different shape. As I previously mentioned, the `otherUser` object will now instead be an array of `otherUsers`, that has the same properties as the existing `otherUser` object. 
Naturally, there will need to be visual updates, such as adding pictures for each user in the chat.

### **If our app were already deployed, what steps would we need to take to move to this new feature without disrupting service for current users?**
We would have to migrate all existing conversations to the new database model. If we did not want to disrupt service, one thing we could do is migrate all the data in the migration file using `migration.RunPython()` and a python function that would handle moving the data. We could grab all entries from the legacy conversation table, and update it accordingly.
Alternatively, we could do something similar where before making the migrations, we could run a python script that moves all the existing conversation data into a local text file. Then after migrations, we could run another script that populated the database with that legacy data.
To be honest, I do not know the best way to accomplish this. I would have to try a few methods and see what works best.

## Notes on your approach and thought process
I went back and forth on how to design the database. I ended up modifying the existing `Conversation` model, as I believe it is more succinct and makes more sense in the long run.
## Further comments (optional)
Tests fail because I modified the models.